### PR TITLE
Features/alter schema and soft delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v0.0.10
+
+- added default fields
+- enabled soft detele as default delete option
+- added archived enpoint when doft delete is enabled
+- updated documentation for README.md
+- updated documentation for TEMPLATES_default.md
+
 # v0.0.9
 
 - added kadira:flow-router and kadira:blaze-layout as weak dependencies

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ If you're familiar with *"Sometimes you gotta run before you can walk."* by Tony
     - [Displays](https://github.com/tooit/meteor-content-types/blob/master/README.md#displays)
     - [Create your own Displays](https://github.com/tooit/meteor-content-types/blob/master/README.md#create-your-own-displays)
     - [Template helpers and events](https://github.com/tooit/meteor-content-types/blob/master/README.md#template-helpers-and-events)
+    - [Default fields support](https://github.com/tooit/meteor-content-types/blob/master/README.md#default-fields-support)
+    - [Soft and Hard delete support](https://github.com/tooit/meteor-content-types/blob/master/README.md#soft-and-hard-delete-support)
     - [Labels](https://github.com/tooit/meteor-content-types/blob/master/README.md#labels)
   - [UI Registered Helpers](https://github.com/tooit/meteor-content-types/blob/master/README.md#ui-registered-helpers)
 - [How this package works](https://github.com/tooit/meteor-content-types/blob/master/README.md#how-this-package-works)
@@ -126,6 +128,7 @@ Done! Out of the box, this code will create this Router routes:
 
 - ``admin/content/books/index``: with a plain list of documents.
 - ``admin/content/books/create``: with an autoform insert form (quickForm).
+- ``admin/content/books/archived``: with a plain list of archived documents ( when soft delete is enabled).
 - ``admin/content/books/:_id``: with a simple table showing all document values.
 - ``admin/content/books/:_id/edit``: with an autoform update form (quickForm).
 - ``admin/content/books/:_id/delete``: with a confirmation page (quickRemoveButton).
@@ -134,6 +137,7 @@ Done! Out of the box, this code will create this Router routes:
 
 - ``Template.CT_index_default_book``: the default Display for the admin/content/books/index route.
 - ``Template.CT_create_default_book``: the default Display for the admin/content/books/create route.
+- ``Template.CT_archived_default_book``: the default Display for the admin/content/books/archived route
 - ``Template.CT_read_default_book``: the default Display for the admin/content/books/read route.
 - ``Template.CT_update_default_book``: the default Display for the admin/content/books/update route.
 - ``Template.CT_delete_default_book``: the default Display for the admin/content/books/delete route.
@@ -295,16 +299,13 @@ BooksCT = new ContentType({
 
 We find ourselfs usually creating our custom Displays to extend some parts of the endpoints default behaviour. Because of that, we added the Template documentation as a start point of creating your own Displays by doing copy+pase from one of the defaults Display templates.
 
-- [CT_index_default](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#ct_index_default)
+- [CT_default_default](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#ct_default_default)
 - [CT_index_default_default](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#ct_index_default_default)
-- [CT_create_default](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#ct_create_default)
 - [CT_create_default_default](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#ct_create_default_default)
-- [CT_read_default](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#ct_read_default)
 - [CT_read_default_default](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#ct_read_default_default)
-- [CT_update_default](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#ct_update_default)
 - [CT_update_default_default](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#ct_update_default_default)
-- [CT_delete_default](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#ct_delete_default)
 - [CT_delete_default_default](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#ct_delete_default_default)
+- [CT_archived_default_default](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#ct_archived_default_default)
 
 For the complete Display Template documentation
 
@@ -352,6 +353,14 @@ BooksCT = new ContentType({
 });
 ```
 
+#### Default fields support
+
+  TODO
+
+#### Soft and Hard delete support
+
+  TODO
+
 #### Labels
 
 Provided templates recieves the ``ct.labels`` object with several text labels. You could modify texts using i18n labels or just create new ones.
@@ -368,6 +377,16 @@ BooksCT = new ContentType({
 ```
 
 ### UI Registered Helpers
+
+``ctSettingEquals``: Compare a Configuration setting against a value.
+
+```handlebars
+...
+{{#if ctSettingEquals 'deleteType' 'soft'}}}}
+  <a href="#">{{ct.labels.linkDelete}}</a>
+{{/if}}
+...
+```
 
 ``ctGetFieldValue``: Needed to get a single property or method from any Object using a dynamic key.
 

--- a/TEMPLATES_default.md
+++ b/TEMPLATES_default.md
@@ -7,16 +7,13 @@ This file shows the templates provided by the "default" theme. This could be use
 - [Introduction](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#Introduction)
 - [Shared template helpers](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#shared_template_helpers)
 - [Templates](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#templates)
-  - [CT_index_default](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#ct_index_default)
-  - [CT_index_default_default](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#ct_index_default_default)
-  - [CT_create_default](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#ct_create_default)
-  - [CT_create_default_default](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#ct_create_default_default)
-  - [CT_read_default](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#ct_read_default)
-  - [CT_read_default_default](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#ct_read_default_default)
-  - [CT_update_default](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#ct_update_default)
-  - [CT_update_default_default](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#ct_update_default_default)
-  - [CT_delete_default](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#ct_delete_default)
-  - [CT_delete_default_default](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#ct_delete_default_default)
+- [CT_default_default](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#ct_default_default)
+- [CT_index_default_default](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#ct_index_default_default)
+- [CT_create_default_default](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#ct_create_default_default)
+- [CT_read_default_default](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#ct_read_default_default)
+- [CT_update_default_default](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#ct_update_default_default)
+- [CT_delete_default_default](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#ct_delete_default_default)
+- [CT_archived_default_default](https://github.com/tooit/meteor-content-types/blob/master/TEMPLATES_default.md#ct_archived_default_default)
 
 ## Introduction
 
@@ -41,13 +38,13 @@ The following keys will be available on all display templates (not on wrapper te
 
 List of Meteor templates provided with the default theme.
 
-### CT_index_default
+### CT_default_default
 
-The wrapper template for ``Index`` endpoint.
+The wrapper template for all the endpoints.
 
 ```handlebars
-<template name="CT_index_default">
-  <div>{{> Template.dynamic template=template }}</div>
+<template name="CT_default_default">
+  <div>{{> UI.dynamic template=template }}</div>
 </template>
 ```
 
@@ -70,7 +67,10 @@ The default display for ``Index`` endpoint.
 
   <ul>
     {{#if ct.pathTo.create}}
-      <li><a href="{{pathFor route=ct.pathTo.create}}" title="{{ct.labels.linkCreate}}">{{ct.labels.linkCreate}}</a></li>
+      <li><a href="{{ctPathFor route=ct.pathTo.create}}" title="{{ct.labels.linkCreate}}">{{ct.labels.linkCreate}}</a></li>
+    {{/if}}
+    {{#if ctSettingEquals 'deleteType' 'soft'}}
+      <li><a href="{{ctPathFor route=ct.pathTo.archive}}" title="{{ct.labels.linkArchive}}">{{ct.labels.linkArchive}}</a></li>
     {{/if}}
   </ul>
 
@@ -93,13 +93,17 @@ The default display for ``Index`` endpoint.
               {{/each}}
               <td>
                 {{#if ct.pathTo.read}}
-                  <a href="{{pathFor route=ct.pathTo.read}}" title="{{ct.labels.linkView}}">{{ct.labels.linkView}}</a>
+                  <a href="{{ctPathFor route=ct.pathTo.read _id=_id}}" title="{{ct.labels.linkView}}">{{ct.labels.linkView}}</a>
                 {{/if}}
                 {{#if ct.pathTo.update}}
-                  <a href="{{pathFor route=ct.pathTo.update}}" title="{{ct.labels.linkEdit}}">{{ct.labels.linkEdit}}</a>
+                  <a href="{{ctPathFor route=ct.pathTo.update _id=_id}}" title="{{ct.labels.linkEdit}}">{{ct.labels.linkEdit}}</a>
                 {{/if}}
-                {{#if ct.pathTo.delete}}
-                  <a href="{{pathFor route=ct.pathTo.delete}}" title="{{ct.labels.linkDelete}}">{{ct.labels.linkDelete}}</a>
+                {{#if ctSettingEquals 'deleteType' 'soft'}}
+                    <a href="" class="ct-soft-delete-btn" data-id="{{_id}}" title="{{ct.labels.linkDelete}}">{{ct.labels.linkDelete}}</a>
+                {{else}}
+                  {{#if ct.pathTo.delete}}
+                    <a href="{{ctPathFor route=ct.pathTo.delete _id=_id}}" title="{{ct.labels.linkDelete}}">{{ct.labels.linkDelete}}</a>
+                  {{/if}}
                 {{/if}}
               </td>
             </tr>
@@ -120,19 +124,9 @@ The default display for ``Index`` endpoint.
 - ``item.total``: total document count.
 - And the rest of common helpers shared by all Index+CRUD endpoints.
 
-### CT_create_default
+#### Template events
 
-The wrapper template for ``Create`` endpoint.
-
-```handlebars
-<template name="CT_create_default">
-  <div>{{> Template.dynamic template=template }}</div>
-</template>
-```
-
-#### Template helpers
-
-- ``template``: a reactive var containing the name of the display to be rendered. You could update this display without running the route again by doing ``MyAwesomeContentType.setDisplay('index', 'new-display');``.
+- ``click .ct-soft-delete-btn``: this handler will fire the soft delete action.
 
 ### CT_create_default_default
 
@@ -151,10 +145,11 @@ The default display for ``Create`` endpoint.
 
   <ul>
     {{#if ct.pathTo.index}}
-      <li><a href="{{pathFor route=ct.pathTo.index}}" title="{{ct.labels.backToIndex}}">{{ct.labels.backToIndex}}</a></li>
+      <li><a href="{{ctPathFor route=ct.pathTo.index}}" title="{{ct.labels.backToIndex}}">{{ct.labels.backToIndex}}</a></li>
     {{/if}}
   </ul>
 </template>
+
 ```
 
 #### Template helpers
@@ -163,20 +158,6 @@ The default display for ``Create`` endpoint.
 - ``formId``: the form id to be used by autoform package.
 - ``formType``: the form type to be used by autoform package.
 - And the rest of common helpers shared by all Index+CRUD endpoints.
-
-### CT_read_default
-
-The wrapper template for ``Read`` endpoint.
-
-```handlebars
-<template name="CT_read_default">
-  <div>{{> Template.dynamic template=template }}</div>
-</template>
-```
-
-#### Template helpers
-
-- ``template``: a reactive var containing the name of the display to be rendered. You could update this display without running the route again by doing ``MyAwesomeContentType.setDisplay('index', 'new-display');``.
 
 ### CT_read_default_default
 
@@ -210,40 +191,51 @@ The default display for ``Read`` endpoint.
         {{/each}}
       </tbody>
     </table>
+  {{/with}}
 
-    <ul>
+
+  <ul>
+    {{#with item}}
       {{#if ct.pathTo.update}}
-        <li><a href="{{pathFor route=ct.pathTo.update}}" title="{{ct.labels.linkEdit}}">{{ct.labels.linkEdit}}</a></li>
+        <li><a href="{{ctPathFor route=ct.pathTo.update _id=_id}}" title="{{ct.labels.linkEdit}}">{{ct.labels.linkEdit}}</a></li>
       {{/if}}
-      {{#if ct.pathTo.delete}}
-        <li><a href="{{pathFor route=ct.pathTo.delete}}" title="{{ct.labels.linkDelete}}">{{ct.labels.linkDelete}}</a></li>
+      {{#if ctSettingEquals 'deleteType' 'soft'}}
+          <li><a href="" class="ct-soft-delete-btn" data-id="{{_id}}" title="{{ct.labels.linkDelete}}">{{ct.labels.linkDelete}}</a></li>
+      {{else}}
+        {{#if ct.pathTo.delete}}
+          <li><a href="{{ctPathFor route=ct.pathTo.delete _id=_id}}" title="{{ct.labels.linkDelete}}">{{ct.labels.linkDelete}}</a></li>
+        {{/if}}
       {{/if}}
       {{#if ct.pathTo.index}}
-        <li><a href="{{pathFor route=ct.pathTo.index}}" title="{{ct.labels.backToIndex}}">{{ct.labels.backToIndex}}</a></li>
+        <li><a href="{{ctPathFor route=ct.pathTo.index}}" title="{{ct.labels.backToIndex}}">{{ct.labels.backToIndex}}</a></li>
       {{/if}}
-    </ul>
-  {{/with}}
+    {{/with}}
+
+    {{#unless item}}
+      {{#if ctSettingEquals 'deleteType' 'soft'}}
+        <li><a href="" class="ct-restore-btn" data-id="{{itemId}}" title="{{ct.labels.linkRestore}}">{{ct.labels.linkRestore}}</a></li>
+      {{/if}}
+      {{#if ct.pathTo.index}}
+        <li><a href="{{ctPathFor route=ct.pathTo.index}}" title="{{ct.labels.backToIndex}}">{{ct.labels.backToIndex}}</a></li>
+      {{/if}}
+      {{#if ctSettingEquals 'deleteType' 'soft'}}
+        <li><a href="{{ctPathFor route=ct.pathTo.archive}}" title="{{ct.labels.backToArchive}}">{{ct.labels.backToArchive}}</a></li>
+      {{/if}}
+    {{/unless}}
+  </ul>
 </template>
 ```
 
 #### Template helpers
 
-- ``item``: the mongo document about to be deleted.
+- ``item``: the mongo document about to be displayed.
+- ``itemId``: the document id, usefull whe soft delete is enabled and de document is archived
 - And the rest of common helpers shared by all Index+CRUD endpoints.
 
-### CT_update_default
+#### Template events
 
-The wrapper template for ``Update`` endpoint.
-
-```handlebars
-<template name="CT_update_default">
-  <div>{{> Template.dynamic template=template }}</div>
-</template>
-```
-
-#### Template helpers
-
-- ``template``: a reactive var containing the name of the display to be rendered. You could update this display without running the route again by doing ``MyAwesomeContentType.setDisplay('index', 'new-display');``.
+- ``click .ct-soft-delete-btn``: this handler will fire the soft delete action.
+- ``click .ct-restore-btn``: this handler will fire the restore action for an archived document.
 
 ### CT_update_default_default
 
@@ -265,15 +257,37 @@ The default display for ``Update`` endpoint.
   <ul>
     {{#with item}}
       {{#if ct.pathTo.read}}
-        <li><a href="{{pathFor route=ct.pathTo.read}}" title="{{ct.labels.linkView}}">{{ct.labels.linkView}}</a></li>
+        <li><a href="{{ctPathFor route=ct.pathTo.read _id=_id}}" title="{{ct.labels.linkView}}">{{ct.labels.linkView}}</a></li>
+      {{/if}}
+      {{#if ctSettingEquals 'deleteType' 'soft'}}
+          <li><a href="" class="ct-soft-delete-btn" data-id="{{_id}}" title="{{ct.labels.linkDelete}}">{{ct.labels.linkDelete}}</a></li>
+      {{else}}
+        {{#if ct.pathTo.delete}}
+          <li><a href="{{ctPathFor route=ct.pathTo.delete _id=_id}}" title="{{ct.labels.linkDelete}}">{{ct.labels.linkDelete}}</a></li>
+        {{/if}}
       {{/if}}
       {{#if ct.pathTo.create}}
-        <li><a href="{{pathFor route=ct.pathTo.create}}" title="{{ct.labels.linkCreate}}">{{ct.labels.linkCreate}}</a></li>
+        <li><a href="{{ctPathFor route=ct.pathTo.create _id=_id}}" title="{{ct.labels.linkCreate}}">{{ct.labels.linkCreate}}</a></li>
+      {{/if}}
+      {{#if ct.pathTo.index}}
+        <li><a href="{{ctPathFor route=ct.pathTo.index}}" title="{{ct.labels.backToIndex}}">{{ct.labels.backToIndex}}</a></li>
       {{/if}}
     {{/with}}
-    {{#if ct.pathTo.index}}
-      <li><a href="{{pathFor route=ct.pathTo.index}}" title="{{ct.labels.backToIndex}}">{{ct.labels.backToIndex}}</a></li>
-    {{/if}}
+
+    {{#unless item}}
+      {{#if ctSettingEquals 'deleteType' 'soft'}}
+        <li><a href="" class="ct-restore-btn" data-id="{{itemId}}" title="{{ct.labels.linkRestore}}">{{ct.labels.linkRestore}}</a></li>
+      {{/if}}
+      {{#if ct.pathTo.create}}
+        <li><a href="{{ctPathFor route=ct.pathTo.create _id=_id}}" title="{{ct.labels.linkCreate}}">{{ct.labels.linkCreate}}</a></li>
+      {{/if}}
+      {{#if ct.pathTo.index}}
+        <li><a href="{{ctPathFor route=ct.pathTo.index}}" title="{{ct.labels.backToIndex}}">{{ct.labels.backToIndex}}</a></li>
+      {{/if}}
+      {{#if ctSettingEquals 'deleteType' 'soft'}}
+        <li><a href="{{ctPathFor route=ct.pathTo.archive}}" title="{{ct.labels.backToArchive}}">{{ct.labels.backToArchive}}</a></li>
+      {{/if}}
+    {{/unless}}
   </ul>
 </template>
 ```
@@ -281,25 +295,17 @@ The default display for ``Update`` endpoint.
 #### Template helpers
 
 - ``item``: the mongo document about to be updated.
+- ``itemId``: the document id, usefull whe soft delete is enabled and de document is archived
 - And the rest of common helpers shared by all Index+CRUD endpoints.
 
-### CT_delete_default
+#### Template events
 
-The wrapper template for ``Delete`` endpoint.
-
-```handlebars
-<template name="CT_delete_default">
-  <div>{{> Template.dynamic template=template }}</div>
-</template>
-```
-
-#### Template helpers
-
-- ``template``: a reactive var containing the name of the display to be rendered. You could update this display without running the route again by doing ``MyAwesomeContentType.setDisplay('index', 'new-display');``.
+- ``click .ct-soft-delete-btn``: this handler will fire the soft delete action.
+- ``click .ct-restore-btn``: this handler will fire the restore action for an archived document.
 
 ### CT_delete_default_default
 
-The default display for ``Create`` endpoint.
+The default display for ``Delete`` endpoint.
 
 ```handlebars
 <template name="CT_delete_default_default">
@@ -320,14 +326,14 @@ The default display for ``Create`` endpoint.
   <ul>
     {{#with item}}
       {{#if ct.pathTo.read}}
-        <li><a href="{{pathFor route=ct.pathTo.read}}" title="{{ct.labels.linkView}}">{{ct.labels.linkView}}</a></li>
+        <li><a href="{{ctPathFor route=ct.pathTo.read _id=_id}}" title="{{ct.labels.linkView}}">{{ct.labels.linkView}}</a></li>
       {{/if}}
       {{#if ct.pathTo.update}}
-        <li><a href="{{pathFor route=ct.pathTo.update}}" title="{{ct.labels.linkEdit}}">{{ct.labels.linkEdit}}</a></li>
+        <li><a href="{{ctPathFor route=ct.pathTo.update _id=_id}}" title="{{ct.labels.linkEdit}}">{{ct.labels.linkEdit}}</a></li>
       {{/if}}
     {{/with}}
     {{#if ct.pathTo.index}}
-      <li><a href="{{pathFor route=ct.pathTo.index}}" title="{{ct.labels.backToIndex}}">{{ct.labels.backToIndex}}</a></li>
+      <li><a href="{{ctPathFor route=ct.pathTo.index}}" title="{{ct.labels.backToIndex}}">{{ct.labels.backToIndex}}</a></li>
     {{/if}}
   </ul>
 </template>
@@ -338,23 +344,66 @@ The default display for ``Create`` endpoint.
 - ``item``: the mongo document about to be deleted.
 - And the rest of common helpers shared by all Index+CRUD endpoints.
 
+### CT_archived_default_default
 
+The default display for ``Archived`` endpoint.
 
+```handlebars
+<template name="CT_archived_default_default">
+  {{#with meta}}
+    {{#if title}}<h2>{{{title}}}</h2>{{/if}}
+    {{#if summary}}<p>{{{summary}}}</p>{{/if}}
+    {{#if help}}<small>{{{help}}}</small>{{/if}}
+    <hr/>
+  {{/with}}
 
+  <ul>
+    {{#if ct.pathTo.create}}
+      <li><a href="{{ctPathFor route=ct.pathTo.create}}" title="{{ct.labels.linkCreate}}">{{ct.labels.linkCreate}}</a></li>
+    {{/if}}
+    {{#if ct.pathTo.index}}
+      <li><a href="{{ctPathFor route=ct.pathTo.index}}" title="{{ct.labels.backToIndex}}">{{ct.labels.backToIndex}}</a></li>
+    {{/if}}
+  </ul>
 
+  {{#with items}}
+    {{#if total}}
+      <table width="100%" border="1">
+        <thead>
+          <tr>
+            {{#each ct.fields}}
+              <th abbr="{{ key }}">{{value}}</th>
+            {{/each}}
+            <th abbr="actions"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {{#each cursor}}
+            <tr>
+              {{#each ct.fields}}
+                <td abbr="{{value}}">{{ctGetFieldValue .. key}}</td>
+              {{/each}}
+              <td>
+                <a href="" class="ct-restore-btn" data-id="{{_id}}" title="{{ct.labels.linkRestore}}">{{ct.labels.linkRestore}}</a>
+              </td>
+            </tr>
+          {{/each}}
+        </tbody>
+      </table>
+      <p>{{ct.labels.totalItemsPrefix}} <strong>{{total}}</strong> {{ct.labels.totalItemsSuffix}}</p>
+    {{else}}
+      <p>{{ct.labels.noItemsFound}}</p>
+    {{/if}}
+  {{/with}}
+</template>
+```
 
+#### Template helpers
 
+- ``item.cursor``: the mongo document reactive cursor.
+- ``item.total``: total document count.
+- And the rest of common helpers shared by all Index+CRUD endpoints.
 
+#### Template events
 
-
-
-
-
-
-
-
-
-
-
-
-
+- ``click .ct-restore-btn``: this handler will fire the restore action for an archived document.

--- a/client/lib/ContentTypes.js
+++ b/client/lib/ContentTypes.js
@@ -4,8 +4,12 @@
 CT = function () {
   this.settings = {
     // The kind of enabled router (iron_router or flow_router).
-    router: 'flow_router'
-  }
+    router: 'flow_router',
+    // Type of delete (soft or hard)
+    deleteType: 'soft',
+    // default content types fields
+    defaultFields: ['title', 'created', 'updated']
+  };
 }
 
 CT.prototype.Configure = function (options) {

--- a/client/lib/UIHelpers.js
+++ b/client/lib/UIHelpers.js
@@ -22,6 +22,7 @@ UI.registerHelper('ctGetFieldValue', function (item, key) {
   return item[key];
 });
 
+
 /**
  * This is the pathFor from iron:router and also implemented in the package
  * arillo:meteor-flow-router-helpers. We add those here to avoid
@@ -85,6 +86,18 @@ UI.registerHelper('ctPathFor', function (options) {
   return url;
 });
 
+/**
+ * This let the user compare a value from ContentTypes settings
+ * key.
+ *
+ * @param  {String} key      The key to read from ContentTypes settings.
+ * @param  {String} value    the value to a make the comparation.
+ *
+ * @return {Boolean} The result of the comparation.
+ */
+UI.registerHelper('ctSettingEquals', function (key, value) {
+  return ContentTypes.getSetting(key) == value;
+});
 
 
 

--- a/client/templates/default/archived.html
+++ b/client/templates/default/archived.html
@@ -1,4 +1,4 @@
-<template name="CT_index_default_default">
+<template name="CT_archived_default_default">
   {{#with meta}}
     {{#if title}}<h2>{{{title}}}</h2>{{/if}}
     {{#if summary}}<p>{{{summary}}}</p>{{/if}}
@@ -10,8 +10,8 @@
     {{#if ct.pathTo.create}}
       <li><a href="{{ctPathFor route=ct.pathTo.create}}" title="{{ct.labels.linkCreate}}">{{ct.labels.linkCreate}}</a></li>
     {{/if}}
-    {{#if ctSettingEquals 'deleteType' 'soft'}}
-      <li><a href="{{ctPathFor route=ct.pathTo.archive}}" title="{{ct.labels.linkArchive}}">{{ct.labels.linkArchive}}</a></li>
+    {{#if ct.pathTo.index}}
+      <li><a href="{{ctPathFor route=ct.pathTo.index}}" title="{{ct.labels.backToIndex}}">{{ct.labels.backToIndex}}</a></li>
     {{/if}}
   </ul>
 
@@ -33,19 +33,7 @@
                 <td abbr="{{value}}">{{ctGetFieldValue .. key}}</td>
               {{/each}}
               <td>
-                {{#if ct.pathTo.read}}
-                  <a href="{{ctPathFor route=ct.pathTo.read _id=_id}}" title="{{ct.labels.linkView}}">{{ct.labels.linkView}}</a>
-                {{/if}}
-                {{#if ct.pathTo.update}}
-                  <a href="{{ctPathFor route=ct.pathTo.update _id=_id}}" title="{{ct.labels.linkEdit}}">{{ct.labels.linkEdit}}</a>
-                {{/if}}
-                {{#if ctSettingEquals 'deleteType' 'soft'}}
-                    <a href="" class="ct-soft-delete-btn" data-id="{{_id}}" title="{{ct.labels.linkDelete}}">{{ct.labels.linkDelete}}</a>
-                {{else}}
-                  {{#if ct.pathTo.delete}}
-                    <a href="{{ctPathFor route=ct.pathTo.delete _id=_id}}" title="{{ct.labels.linkDelete}}">{{ct.labels.linkDelete}}</a>
-                  {{/if}}
-                {{/if}}
+                <a href="" class="ct-restore-btn" data-id="{{_id}}" title="{{ct.labels.linkRestore}}">{{ct.labels.linkRestore}}</a>
               </td>
             </tr>
           {{/each}}
@@ -57,3 +45,4 @@
     {{/if}}
   {{/with}}
 </template>
+

--- a/client/templates/default/read.html
+++ b/client/templates/default/read.html
@@ -25,17 +25,36 @@
         {{/each}}
       </tbody>
     </table>
+  {{/with}}
 
-    <ul>
+
+  <ul>
+    {{#with item}}
       {{#if ct.pathTo.update}}
         <li><a href="{{ctPathFor route=ct.pathTo.update _id=_id}}" title="{{ct.labels.linkEdit}}">{{ct.labels.linkEdit}}</a></li>
       {{/if}}
-      {{#if ct.pathTo.delete}}
-        <li><a href="{{ctPathFor route=ct.pathTo.delete _id=_id}}" title="{{ct.labels.linkDelete}}">{{ct.labels.linkDelete}}</a></li>
+      {{#if ctSettingEquals 'deleteType' 'soft'}}
+          <li><a href="" class="ct-soft-delete-btn" data-id="{{_id}}" title="{{ct.labels.linkDelete}}">{{ct.labels.linkDelete}}</a></li>
+      {{else}}
+        {{#if ct.pathTo.delete}}
+          <li><a href="{{ctPathFor route=ct.pathTo.delete _id=_id}}" title="{{ct.labels.linkDelete}}">{{ct.labels.linkDelete}}</a></li>
+        {{/if}}
       {{/if}}
       {{#if ct.pathTo.index}}
         <li><a href="{{ctPathFor route=ct.pathTo.index}}" title="{{ct.labels.backToIndex}}">{{ct.labels.backToIndex}}</a></li>
       {{/if}}
-    </ul>
-  {{/with}}
+    {{/with}}
+
+    {{#unless item}}
+      {{#if ctSettingEquals 'deleteType' 'soft'}}
+        <li><a href="" class="ct-restore-btn" data-id="{{itemId}}" title="{{ct.labels.linkRestore}}">{{ct.labels.linkRestore}}</a></li>
+      {{/if}}
+      {{#if ct.pathTo.index}}
+        <li><a href="{{ctPathFor route=ct.pathTo.index}}" title="{{ct.labels.backToIndex}}">{{ct.labels.backToIndex}}</a></li>
+      {{/if}}
+      {{#if ctSettingEquals 'deleteType' 'soft'}}
+        <li><a href="{{ctPathFor route=ct.pathTo.archive}}" title="{{ct.labels.backToArchive}}">{{ct.labels.backToArchive}}</a></li>
+      {{/if}}
+    {{/unless}}
+  </ul>
 </template>

--- a/client/templates/default/update.html
+++ b/client/templates/default/update.html
@@ -15,12 +15,34 @@
       {{#if ct.pathTo.read}}
         <li><a href="{{ctPathFor route=ct.pathTo.read _id=_id}}" title="{{ct.labels.linkView}}">{{ct.labels.linkView}}</a></li>
       {{/if}}
+      {{#if ctSettingEquals 'deleteType' 'soft'}}
+          <li><a href="" class="ct-soft-delete-btn" data-id="{{_id}}" title="{{ct.labels.linkDelete}}">{{ct.labels.linkDelete}}</a></li>
+      {{else}}
+        {{#if ct.pathTo.delete}}
+          <li><a href="{{ctPathFor route=ct.pathTo.delete _id=_id}}" title="{{ct.labels.linkDelete}}">{{ct.labels.linkDelete}}</a></li>
+        {{/if}}
+      {{/if}}
       {{#if ct.pathTo.create}}
         <li><a href="{{ctPathFor route=ct.pathTo.create _id=_id}}" title="{{ct.labels.linkCreate}}">{{ct.labels.linkCreate}}</a></li>
       {{/if}}
+      {{#if ct.pathTo.index}}
+        <li><a href="{{ctPathFor route=ct.pathTo.index}}" title="{{ct.labels.backToIndex}}">{{ct.labels.backToIndex}}</a></li>
+      {{/if}}
     {{/with}}
-    {{#if ct.pathTo.index}}
-      <li><a href="{{ctPathFor route=ct.pathTo.index}}" title="{{ct.labels.backToIndex}}">{{ct.labels.backToIndex}}</a></li>
-    {{/if}}
+
+    {{#unless item}}
+      {{#if ctSettingEquals 'deleteType' 'soft'}}
+        <li><a href="" class="ct-restore-btn" data-id="{{itemId}}" title="{{ct.labels.linkRestore}}">{{ct.labels.linkRestore}}</a></li>
+      {{/if}}
+      {{#if ct.pathTo.create}}
+        <li><a href="{{ctPathFor route=ct.pathTo.create _id=_id}}" title="{{ct.labels.linkCreate}}">{{ct.labels.linkCreate}}</a></li>
+      {{/if}}
+      {{#if ct.pathTo.index}}
+        <li><a href="{{ctPathFor route=ct.pathTo.index}}" title="{{ct.labels.backToIndex}}">{{ct.labels.backToIndex}}</a></li>
+      {{/if}}
+      {{#if ctSettingEquals 'deleteType' 'soft'}}
+        <li><a href="{{ctPathFor route=ct.pathTo.archive}}" title="{{ct.labels.backToArchive}}">{{ct.labels.backToArchive}}</a></li>
+      {{/if}}
+    {{/unless}}
   </ul>
 </template>

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,0 +1,27 @@
+if (Meteor.isServer) {
+  Global = this;
+}
+if (Meteor.isClient) {
+  Global = window;
+}
+
+CommonHelpers = {};
+
+/**
+ * Find a Mongo.Collection instance.
+ * Get the instance of a Mongo.Collection given the collection name
+ *
+ * @param  {String} name  The name of the collection.
+ */
+CommonHelpers.getCollection = function (name) {
+
+  for (var object in Global) {
+    if (Global[object] instanceof Meteor.Collection) {
+      if (Global[object]['_name'] === name) {
+        return (Global[object]);
+        break;
+      };
+    }
+  }
+  return undefined; // if none of the collections match
+};

--- a/lib/defaultSchemaFields.js
+++ b/lib/defaultSchemaFields.js
@@ -1,0 +1,45 @@
+/**
+ * Default Fields schema specification.
+ *
+ * Used to alter the current schema attached to a collection,
+ * @see ContentTypes.defaultFields
+ * @see ContentType.initialize
+ * @see Meteor.methods.alterSchema
+*/
+
+defaultFieldsSchema = {
+  title: { title : {
+    type: String,
+    label: "Title",
+    max: 200,
+  }},
+  created: { created: {
+    type: Date,
+    autoValue: function() {
+      if (this.isInsert) {
+        return new Date;
+      } else if (this.isUpsert) {
+        return {$setOnInsert: new Date};
+      } else {
+        this.unset();  // Prevent user from supplying their own value
+      }
+    },
+    autoform: { omit: true }
+  }},
+  updated: { updated: {
+    type: Date,
+    autoValue: function() {
+      if (this.isUpdate) {
+        return new Date();
+      }
+    },
+    optional: true,
+    denyInsert: true,
+    autoform: { omit: true }
+  }},
+  archived: { archived: {
+    type: Date,
+    optional: true,
+    autoform: { omit: true }
+  }}
+};

--- a/lib/methods.js
+++ b/lib/methods.js
@@ -1,0 +1,45 @@
+Meteor.methods({
+
+  /**
+   * Add default schema fields to the user collection.
+   *
+   * @param  {String} collection The name of the collection from wich alter the schema.
+   * @param  {Array} fields      The field to add to the given collection schema.
+   * @see   defaultFieldsSchema object
+   */
+  alterSchema: function (collection, fields) {
+    var collecionInstance = CommonHelpers.getCollection(collection);
+
+    if (!Match.test(collecionInstance, undefined)) {
+      _.each(fields, function(field, key) {
+        if (Match.test(defaultFieldsSchema[field], Object)) {
+          collecionInstance.attachSchema(defaultFieldsSchema[field]);
+        }
+      });
+    }
+  },
+
+  /**
+   * Mark a document as archived.
+   * Used when soft delete is enabled.
+   *
+   * @param  {String} collection  The name of the collection from where find the document.
+   * @param  {String} id          The document id to mark as archived.
+   */
+  archive: function (collection, id) {
+    var collecionInstance = CommonHelpers.getCollection(collection);
+    collecionInstance.update(id, { $set: { archived: new Date() } });
+  },
+
+  /**
+   * Unmark a document as archived.
+   * Used when soft delete is enabled.
+   *
+   * @param  {String} collection  The name of the collection from where find the document.
+   * @param  {String} id          The document id to unmark as archived.
+   */
+  restore: function (collection, id) {
+    var collecionInstance = CommonHelpers.getCollection(collection);
+    collecionInstance.update(id, { $set: { archived: null } });
+  },
+});

--- a/package.js
+++ b/package.js
@@ -33,11 +33,18 @@ Package.onUse(function(api) {
     'client/lib/UIHelpers.js',
     'client/templates/default/_wrapper.html',
     'client/templates/default/index.html',
+    'client/templates/default/archived.html',
     'client/templates/default/create.html',
     'client/templates/default/read.html',
     'client/templates/default/update.html',
     'client/templates/default/delete.html'
   ], 'client');
+
+  api.addFiles([
+    'lib/common.js',
+    'lib/methods.js',
+    'lib/defaultSchemaFields.js'
+  ]);
 
   api.export([
     'ContentType',


### PR DESCRIPTION
#### Added default fields and soft delete features.

On ContentType initialization,  the collection schema is altered adding the default fields. If soft delete is enabled (enabled by default), archived field is also added to the collection schema.

If soft delete is enabled, a new endpoint is added to list all the archived documents. The default templates were modified to make use of soft delete.

Documentation was also modified to reflect all the changes.
